### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -12,6 +12,10 @@ xindy (2.5.1.20160104-9) UNRELEASED; urgency=medium
   * Apply patch for #968437, thanks to
     Petter Reinholdtsen <pere@hungry.com>.
 
+  [ Debian Janitor ]
+  * Apply multi-arch hints.
+    + xindy-rules: Add Multi-Arch: foreign.
+
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 10:26:37 +0000
 
 xindy (2.5.1.20160104-8) unstable; urgency=medium

--- a/debian/control
+++ b/debian/control
@@ -33,6 +33,7 @@ Package: xindy-rules
 Architecture: all
 Depends: ${misc:Depends}
 Recommends: xindy
+Multi-Arch: foreign
 Description: rule files for xindy
  xindy is an index processor that can be used to generate book-like
  indexes for arbitrary document-preparation systems.


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* xindy-rules: Add Multi-Arch: foreign. This fixes: xindy-rules could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/xindy/5fdf8c15-2635-4ace-87c7-ac2754e7f213.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/11/b6d6105873a45951702889d2a5199fb3768615.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/70/3b1feed2034c1d61aed21ba0c88588b9448325.debug

No differences were encountered between the control files of package \*\*xindy\*\*
### Control files of package xindy-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-703b1feed2034c1d61aed21ba0c88588b9448325-] {+11b6d6105873a45951702889d2a5199fb3768615+}
### Control files of package xindy-rules: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5fdf8c15-2635-4ace-87c7-ac2754e7f213/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5fdf8c15-2635-4ace-87c7-ac2754e7f213/diffoscope)).
