### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+xindy (2.5.1.20160104-11) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on clisp.
+    + xindy: Drop versioned constraint on clisp in Depends.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 24 Aug 2021 03:55:34 -0000
+
 xindy (2.5.1.20160104-10) unstable; urgency=medium
 
   * Apply patch from xindy PR 6 to fix hyperref compatibility.

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends-Indep: texlive-latex-base,
 	cm-super
 Build-Depends: debhelper-compat (= 12),
 	flex,
-	clisp (>= 1:2.49.20180212)
+	clisp
 Standards-Version: 4.5.1
 Homepage: http://www.xindy.org/
 Vcs-Git: https://github.com/debian-tex/xindy.git
@@ -21,7 +21,7 @@ Vcs-Browser: https://github.com/debian-tex/xindy
 Package: xindy
 Architecture: any
 Depends: xindy-rules, ${clisp:Depends}, ${shlibs:Depends}, ${perl:Depends},
-  ${misc:Depends}, clisp (>= 1:2.49.20180212)
+  ${misc:Depends}, clisp
 Description: index generator for structured documents like LaTeX or SGML
  xindy is an index processor that can be used to generate book-like
  indexes for arbitrary document-preparation systems. This includes


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/xindy/33ba8ed2-2ed0-4da9-bcee-53a47061f17e.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package xindy: lines which differ (wdiff format)
* Depends: xindy-rules, clisp-memfile-hash-a78ccb7e22a02ed0aaff6727ac81d18307454a33, libc6 (>= 2.14), perl:any, clisp [-(>= 1:2.49.20180212)-]

No differences were encountered between the control files of package \*\*xindy-dbgsym\*\*

No differences were encountered between the control files of package \*\*xindy-rules\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/33ba8ed2-2ed0-4da9-bcee-53a47061f17e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/33ba8ed2-2ed0-4da9-bcee-53a47061f17e/diffoscope)).
